### PR TITLE
fix: add Suspense boundaries for useSearchParams() across all pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ To get a local copy up and running, follow these simple steps.
     ```
 2.  **Install NPM packages**
     ```sh
-    npm install
+    pnpm install
     ```
 3.  **Set up environment variables**
     * Create a `.env.local` file in the root of the project.

--- a/app/register/set-password/page.tsx
+++ b/app/register/set-password/page.tsx
@@ -2,7 +2,7 @@
 
 import type React from "react"
 
-import { useState, useEffect } from "react"
+import { useState, useEffect, Suspense } from "react"
 import { useRouter, useSearchParams } from "next/navigation"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
@@ -13,7 +13,7 @@ import Image from "next/image"
 import supabaseClient from "@/lib/supabase/supabaseClient"
 import { sha256 } from "js-sha256"
 
-export default function SetPasswordPage() {
+function SetPasswordContent() {
   const [password, setPassword] = useState("")
   const [confirmPassword, setConfirmPassword] = useState("")
   const [loading, setLoading] = useState(false)
@@ -269,5 +269,23 @@ export default function SetPasswordPage() {
         </div>
       </div>
     </div>
+  )
+}
+
+// Loading component for Suspense fallback
+function SetPasswordLoading() {
+  return (
+    <div className="min-h-screen bg-[#0f2d3c] flex items-center justify-center">
+      <div className="animate-spin rounded-full h-12 w-12 border-t-2 border-b-2 border-white"></div>
+    </div>
+  )
+}
+
+// Main component wrapped with Suspense
+export default function SetPasswordPage() {
+  return (
+    <Suspense fallback={<SetPasswordLoading />}>
+      <SetPasswordContent />
+    </Suspense>
   )
 }

--- a/app/reset-password/page.tsx
+++ b/app/reset-password/page.tsx
@@ -2,7 +2,7 @@
 
 import type React from "react"
 
-import { useState, useEffect } from "react"
+import { useState, useEffect, Suspense } from "react"
 import { useSearchParams, useRouter } from "next/navigation"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
@@ -13,7 +13,7 @@ import Image from "next/image"
 import supabaseClient from "@/lib/supabase/supabaseClient"
 import { sha256 } from "js-sha256"
 
-function ResetPassword() {
+function ResetPasswordContent() {
   const [password, setPassword] = useState("")
   const [confirmPassword, setConfirmPassword] = useState("")
   const [showPassword, setShowPassword] = useState(false)
@@ -329,7 +329,20 @@ function ResetPassword() {
   )
 }
 
+// Loading component for Suspense fallback
+function ResetPasswordLoading() {
+  return (
+    <div className="min-h-screen bg-[#0f2d3c] flex items-center justify-center">
+      <div className="animate-spin rounded-full h-12 w-12 border-t-2 border-b-2 border-white"></div>
+    </div>
+  )
+}
+
 // Add this at the very end of the file, after the existing component
 export default function Page() {
-  return <ResetPassword />
+  return (
+    <Suspense fallback={<ResetPasswordLoading />}>
+      <ResetPasswordContent />
+    </Suspense>
+  )
 }

--- a/app/results/page.tsx
+++ b/app/results/page.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import React, { useState, useEffect, useCallback } from "react"
+import React, { useState, useEffect, useCallback, Suspense } from "react"
 import { useSearchParams, useRouter } from "next/navigation"
 import { ChevronLeft, ChevronRight, Info, Plane, Calendar, ChevronDown, ArrowRight, AlertCircle, X } from "lucide-react"
 import Link from "next/link"
@@ -84,7 +84,7 @@ interface PassengerDetails {
   travelClass: string
 }
 
-export default function ResultsPage(href: string, options?: NavigateOptions) {
+function ResultsPageContent() {
   const searchParams = useSearchParams()
   const router = useRouter()
   const [loading, setLoading] = useState(true)
@@ -1237,5 +1237,23 @@ export default function ResultsPage(href: string, options?: NavigateOptions) {
         </div>
       )}
     </main>
+  )
+}
+
+// Loading component for Suspense fallback
+function ResultsPageLoading() {
+  return (
+    <div className="min-h-screen bg-[#0f2d3c] flex items-center justify-center">
+      <div className="animate-spin rounded-full h-12 w-12 border-t-2 border-b-2 border-white"></div>
+    </div>
+  )
+}
+
+// Main component wrapped with Suspense
+export default function ResultsPage() {
+  return (
+    <Suspense fallback={<ResultsPageLoading />}>
+      <ResultsPageContent />
+    </Suspense>
   )
 }


### PR DESCRIPTION
This pull request refactors several page components to improve loading state handling by introducing React's `Suspense` with custom loading spinners. It also updates the package installation instructions in the `README.md` to use `pnpm` instead of `npm`. The most important changes are grouped below:

**Improved Loading State Handling with Suspense:**

* Refactored `ResultsPage`, `SetPasswordPage`, and `ResetPassword` components by splitting out their main content into separate components (`ResultsPageContent`, `SetPasswordContent`, `ResetPasswordContent`). Each page now uses React's `Suspense` to wrap the content and display a custom loading spinner while loading. [[1]](diffhunk://#diff-ab758472511e3898e9f8aad0b3e0991526710ac333d92d486ac10c5c071868a0L87-R87) [[2]](diffhunk://#diff-ab758472511e3898e9f8aad0b3e0991526710ac333d92d486ac10c5c071868a0R1242-R1259) [[3]](diffhunk://#diff-486e0c832549c78e6114c16c6a66510fb5b9a2e14124ec24881d44d18215614aL16-R16) [[4]](diffhunk://#diff-486e0c832549c78e6114c16c6a66510fb5b9a2e14124ec24881d44d18215614aR274-R291) [[5]](diffhunk://#diff-ad47e410af6af81868f924ac99051fc2d589b6108944350c35e01d998dba1215L16-R16) [[6]](diffhunk://#diff-ad47e410af6af81868f924ac99051fc2d589b6108944350c35e01d998dba1215R332-R347)
* Added dedicated loading spinner components (`ResultsPageLoading`, `SetPasswordLoading`, `ResetPasswordLoading`) for each page to provide a consistent and visually appealing loading experience. [[1]](diffhunk://#diff-ab758472511e3898e9f8aad0b3e0991526710ac333d92d486ac10c5c071868a0R1242-R1259) [[2]](diffhunk://#diff-486e0c832549c78e6114c16c6a66510fb5b9a2e14124ec24881d44d18215614aR274-R291) [[3]](diffhunk://#diff-ad47e410af6af81868f924ac99051fc2d589b6108944350c35e01d998dba1215R332-R347)
* Updated imports in affected files to include `Suspense` from React. [[1]](diffhunk://#diff-ab758472511e3898e9f8aad0b3e0991526710ac333d92d486ac10c5c071868a0L3-R3) [[2]](diffhunk://#diff-486e0c832549c78e6114c16c6a66510fb5b9a2e14124ec24881d44d18215614aL5-R5) [[3]](diffhunk://#diff-ad47e410af6af81868f924ac99051fc2d589b6108944350c35e01d998dba1215L5-R5)

**Documentation Update:**

* Changed the local setup instructions in `README.md` to use `pnpm install` instead of `npm install` for installing dependencies.